### PR TITLE
Started trying to tackle the main file. Jeff said to axe the find_dir…

### DIFF
--- a/data-quality-assessment/common.py
+++ b/data-quality-assessment/common.py
@@ -61,7 +61,10 @@ def koaid(keywords, utDate):
 
         instr = keywords['INSTRUME'].lower()
         outdir = keywords['OUTDIR']
-       # camera = keywords['CAMERA'].lower()
+        try:
+                camera = keywords['CAMERA'].lower()
+        except KeyError:
+                logging.warning('No keyword CAMERA exists for {}'.format(instr))
 
         if instr in instr_prefix:
                 prefix = instr_prefix[instr]
@@ -85,7 +88,7 @@ def koaid(keywords, utDate):
         elif instr == 'osiris':
                 if '/SCAM' in outdir:
                         prefix = 'OI'
-                elif '/SPEC' in 'osiris':
+                elif '/SPEC' in outdir:
                         prefix = 'OS'
         else:
                 print('Cannot determine prefix')
@@ -95,5 +98,3 @@ def koaid(keywords, utDate):
         koaid = prefix + '.' + utDate + '.' + totalSeconds.zfill(5) + '.fits'
         keywords['KOAID'] = koaid
         return True
-
-# testing pull requests - Matt

--- a/dep-locate/dep_locate.py
+++ b/dep-locate/dep_locate.py
@@ -34,11 +34,39 @@ def dep_locate(instr, utDate, stageDir):
     verify_date(utDate)
     assert stageDir != '', 'stageDir value is blank'
 
+# Init of dep_locate. will come back to this later
+'''
+    if not sub.run(['mkdir','-p', ancDir+'/udf']):
+        logging.warning("Unable to create udf directory!")
+
+    oFileName = stageDir + '/dep_locate' + instr + '.txt'
+    ofile = open(oFileName, 'w')
+
+'''
+
     # Which sdata disk?
-    locate.getDirList(instr)
+    subdir = locate.getDirList(instr)
+    # locate did not return any dirs, so we exit
+    if len(subdir) == 0:
+        return
 
     # Locate FITS files written in the last 24 hours
-	
+    usedir = subdir
+    for i in range(1,2):
+        if i==1:
+            log_file = stageDir + "/dep_locate1" + instr + ".txt"
+        elif i==2:
+            log_file = stageDir + "/dep_locate2" + instr + ".txt"
+        file1 = stageDir + "/dep_locate" + instr + "1.txt"
+        file2 = stageDir + "/dep_locate" + instr + "2.txt"
+        file3 = stageDir + "/dep_locate" + instr + "3.txt"
+
+        # Day 1, if not last night
+        howold -= 1
+        if howold < 0:
+            sub.run(['find', usedir, '-mtime', howold, '-name', '\*.fits', '!', '-name', 'fcs\*.fits', '-fprintf', file1,'"%p %CT %CZ %CY/%Cm/%Cd\n"])
+        
+
     # Verify FITS files and create stageDir/dep_locateINSTR.txt
 
 


### PR DESCRIPTION
abstracted the logging and fits file move to its own function. function takes the instrument, file, anc directory and an error code which is based on where the file fails

the portion of rawfiles that constructs a filename from the header data has been moved to its own function. 

I added a style of commenting similar to Javadoc/Doxygen that can be used with the Epydoc API from epydoc.sourceforge.net