### PR TITLE
Fixed prefix bug, added logging to instrument class

### DIFF
--- a/deimos.py
+++ b/deimos.py
@@ -55,8 +55,9 @@ class Deimos(instrument.Instrument):
     def set_prefix(self, keys):
         instr = self.set_instr(keys)
         if '/fcs' in keys[self.outdir]:
-            self.prefix = 'DF'
+            prefix = 'DF'
         elif instr == 'deimos':
-            self.prefix = 'DE'
+            prefix = 'DE'
         else:
-            self.prefix = ''
+            prefix = ''
+        return prefix

--- a/esi.py
+++ b/esi.py
@@ -43,6 +43,7 @@ class Esi(instrument.Instrument):
     def set_prefix(self, keys):
         instr = self.set_prefix(keys)
         if instr == 'esi':
-            self.prefix = 'EI'
+            prefix = 'EI'
         else:
-            self.prefix = ''
+            prefix = ''
+        return prefix

--- a/hires.py
+++ b/hires.py
@@ -50,6 +50,7 @@ class Hires(instrument.Instrument):
     def set_prefix(self, keys):
         instr = self.set_instr(keys)
         if instr == 'hires':
-            self.prefix = 'HI'
+            prefix = 'HI'
         else:
-            self.prefix = ''
+            prefix = ''
+        return prefix

--- a/instrument.py
+++ b/instrument.py
@@ -7,6 +7,8 @@ Children will contain the instrument specific values
 """
 
 import datetime as dt
+import logging as lg
+import os
 
 class Instrument:
     def __init__(self, endTime=dt.datetime.now()):
@@ -47,6 +49,16 @@ class Instrument:
         self.koaid = ''
         self.paths = []
         self.keys = {}
+
+        # Separate section for log init
+        user = os.getLogin()
+        self.log = lg.getLogger(user)
+        self.log.setLevel(lg.INFO)
+        fh = lg.FileHandler(type(self).__name__ + 'Log.txt')
+        fh.setLevel(lg.INFO)
+        fmat = lg.Formatter('%(asctime)s - %(name)s - %(levelname)s: %(message)s')
+        fh.setFormatter(fmat)
+        self.log.addHandler(fh)
 
     def make_koaid(self, keys):
         """

--- a/instrument.py
+++ b/instrument.py
@@ -11,16 +11,19 @@ import datetime as dt
 class Instrument:
     def __init__(self, endTime=dt.datetime.now()):
         """
+        Base Instrument class to hold all the values common between
+        instruments. Contains default values where possible
+        but null values should be replaced in the init of the 
+        subclasses.
         """
 
         # Keyword values to be used with a FITS file during runtime
-        self.instr = 'INSTRUME'
+        self.instrume = 'INSTRUME'
         self.utc = 'UTC'
         self.dateObs = 'DATE'
         self.semester = 'SEMESTER'
         self.fileRoot = 'OUTFILE'        # Can be DATAFILE or ROOTNAME for specific instruments
         self.frameno = 'FRAMENO'     # Can be IMGNUM, FRAMENUM, FILENUM1, FILENUM2
-        self.koaid = 'KOAID'
         self.outdir = 'OUTDIR'
         self.ftype = 'INSTR'         # For instruments with two file types
         try: # Let's see if endTime was passed as a string
@@ -35,36 +38,72 @@ class Instrument:
             self.endHour = endTime.strftime('%H:%M:%S')
 
         # Values to be populated by subclass
+        self.instr = ''
         self.prefix = ''
         self.origFile = ''
         self.rootDir = ''
         self.stageDir = ''
         self.ancDir = ''
+        self.koaid = ''
         self.paths = []
         self.keys = {}
 
-    def koaid(self, keys):
-        utc = keys[self.utc]
-        dateobs = keys[self.dateObs]
+    def make_koaid(self, keys):
+        """
+        Function to create the KOAID for a given FITS file
+        Returns the TRUE if the KOAID is successfully created
+        and stored in the KOAID member variable
+
+        @type keys: dictionary
+        @param keys: The header for the given FITS file
+        """
+        # Get the prefix for the correct instrument and configuration
+        # Note: set_prefix() is a subclass method
+        self.prefix = self.set_prefix(keys)
+        if self.prefix == '':
+            return False
+
+        # Extract the UTC time and date observed from the header
+        try:
+            utc = keys[self.utc]
+            dateobs = keys[self.dateObs]
+        except KeyError:
+            return False
+
+        # Create a timedate object using the string from the header
         try:
             utc = datetime.strptime(utc, '%H:%M:%S.%f')
         except ValueError:
-            raise ValueError
+            return False
 
+        # Extract the hour, minute, and seconds from the UTC time
         hour = utc.hour
         minute = utc.minute
         second = utc.second
 
-        totalSeconds = str((hour*3600) + (minute*60) + second)
+        # Calculate the total number of seconds since Midnight
+        seq = (str(hour*3600), str(minute*60), str(second))
+        totalSeconds = ''.join(seq)
 
+        # Remove any date separators from the date
         dateobs = dateobs.replace('-','')
         dateobs = dateobs.replace('/','')
+
+        # Create the KOAID from the parts
         seq = (self.prefix, '.', dateobs, '.', totalseconds.zfill(5), '.fits')
         self.koaid = ''.join(seq)
         return True
 
     def set_instr(self, keys):
-        instr = keys[self.instr].lower()
+        """
+        Method to extract the name of the instrument from the INSTRUME keyword value
+        """
+        # Extract the Instrume value from the header as lowercase
+        instr = keys[self.instrume].lower()
+
+        # Split the value up into an array 
         instr = instr.split(' ')
+
+        # The instrument name should always be the first value
         instr = instr[0].replace(':','')
         return instr

--- a/kcwi.py
+++ b/kcwi.py
@@ -47,15 +47,15 @@ class Kcwi(instrument.Instrument):
             try:
                 camera = keys['CAMERA'].lower()
             except KeyError:
-                self.prefix = ''
-                raise KeyError
+                prefix = ''
             if camera == 'blue':
-                self.prefix = 'KB'
+                prefix = 'KB'
             elif camera == 'red':
-                self.prefix = 'KR'
+                prefix = 'KR'
             elif camera == 'fpc':
-                self.prefix = 'KF'
+                prefix = 'KF'
             else:
-                self.prefix = ''
+                prefix = ''
         else:
-            self.prefix = ''
+            prefix = ''
+        return prefix

--- a/lris.py
+++ b/lris.py
@@ -39,8 +39,9 @@ class Lris(instrument.Instrument):
     def set_prefix(self, keys):
         instr = self.set_instr(keys)
         if instr == 'lrisblue':
-            self.prefix = 'LB'
+            prefix = 'LB'
         elif instr == 'lris':
-            self.prefix = 'LR'
+            prefix = 'LR'
         else:
-            self.prefix = ''
+            prefix = ''
+        return prefix

--- a/mosfire.py
+++ b/mosfire.py
@@ -48,6 +48,7 @@ class Mosfire(instrument.Instrument):
     def set_prefix(self, keys):
         instr = self.set_instr(keys)
         if instr == 'mosfire':
-            self.prefix = 'MF'
+            prefix = 'MF'
         else:
-            self.prefix = ''
+            prefix = ''
+        return prefix

--- a/nirc2.py
+++ b/nirc2.py
@@ -46,6 +46,7 @@ class Nirc2(instrument.Instrument):
     def set_prefix(self, keys):
         instr = self.set_prefix(keys)
         if instr == 'nirc2':
-            self.prefix = 'N2'
+            prefix = 'N2'
         else:
-            self.prefix = ''
+            prefix = ''
+        return prefix

--- a/nires.py
+++ b/nires.py
@@ -47,11 +47,19 @@ class Nires(instrument.Instrument):
         Defaults to nullstr
         '''
         instr = self.set_instr(keys)
-        ftype = keys['INSTR']
-        if ftype == 'imag':
-            self.prefix = 'NI'
-        elif ftype == 'spec':
-            self.prefix = 'NR'
+        if instr == 'nires':
+            try:
+                ftype = keys['INSTR']
+            except KeyError:
+                prefix = ''
+            else:
+                if ftype == 'imag':
+                    prefix = 'NI'
+                elif ftype == 'spec':
+                    prefix = 'NR'
+                else:
+                    prefix = ''
         else:
-            self.prefix = ''
+            prefix = ''
+        return prefix
 

--- a/nirspec.py
+++ b/nirspec.py
@@ -49,13 +49,18 @@ class Nirspec(instrument.Instrument):
 
     def set_prefix(self, keys):
         instr = self.set_instr(keys)
-        outdir = keys[self.outdir]
         if instr == 'nirspec':
-            if '/scam' in outdir:
-                self.prefix = 'NC'
-            elif '/spec' in outdir:
-                self.prefix = 'NS'
+            try:
+                outdir = keys[self.outdir]
+            except KeyError:
+                prefix = ''
             else:
-                self.prefix = ''
+                if '/scam' in outdir:
+                    prefix = 'NC'
+                elif '/spec' in outdir:
+                    prefix = 'NS'
+                else:
+                    prefix = ''
         else:
-            self.prefix = ''
+            prefix = ''
+       return prefix

--- a/osiris.py
+++ b/osiris.py
@@ -46,13 +46,18 @@ class Osiris(instrument.Instrument):
 
     def set_prefix(self, keys):
         instr = self.set_instr(keys)
-        outdir = keys[self.outdir]
         if instr == 'osiris':
-            if '/scam' in outdir:
-                self.prefix = 'OI'
-            elif '/spec' in outdir:
-                self.prefix = 'OS'
+            try:
+                outdir = keys[self.outdir]
+            except KeyError:
+                prefix = ''
             else:
-                self.prefix = ''
+                if '/scam' in outdir:
+                    prefix = 'OI'
+                elif '/spec' in outdir:
+                    prefix = 'OS'
+                else:
+                    prefix = ''
         else:
-            self.prefix = ''
+           prefix = ''
+        return prefix


### PR DESCRIPTION
The set_prefix functions where being used to assign a value, but it was not returning a value. So I made it return the prefix chosen.

instrument has a generalized log setup that will specialize with each subclass. each instrument will not have a <instrumentname>Log.txt file associated with it.