### PR TITLE
Fixed error condition where fits.writeto throws exception but it writ…

### DIFF
--- a/instrument.py
+++ b/instrument.py
@@ -921,6 +921,9 @@ class Instrument:
                 self.log.info('write_lev0_fits_file: Forced to write FITS using output_verify="ignore". May want to inspect:' + outfile)                
             except Exception as e:
                 self.log.error('write_lev0_fits_file: Could not write out lev0 FITS file to ' + outfile)
+                self.log.info(str(e))
+                if os.path.isfile(outfile):
+                    os.remove(outfile)
                 return False
 
         return True


### PR DESCRIPTION
…es the file out anyway which causes metadata.py to break in some cases. Now will delete file explicitly if exists.